### PR TITLE
Do not allow null for self info

### DIFF
--- a/src/main/cpp/tox/core.cpp
+++ b/src/main/cpp/tox/core.cpp
@@ -361,7 +361,7 @@ new_tox_self_set_name (new_Tox *tox, uint8_t const *name, size_t length, TOX_ERR
       if (error) *error = TOX_ERR_SET_INFO_TOO_LONG;
       return false;
     }
-  if (name == nullptr)
+  if (length > 0 && name == nullptr)
     {
       if (error) *error = TOX_ERR_SET_INFO_NULL;
       return false;
@@ -409,7 +409,7 @@ new_tox_self_set_status_message (new_Tox *tox, uint8_t const *status, size_t len
       if (error) *error = TOX_ERR_SET_INFO_TOO_LONG;
       return false;
     }
-  if (status == nullptr)
+  if (length > 0 && status == nullptr)
     {
       if (error) *error = TOX_ERR_SET_INFO_NULL;
       return false;

--- a/src/main/cpp/tox/core.cpp
+++ b/src/main/cpp/tox/core.cpp
@@ -361,7 +361,7 @@ new_tox_self_set_name (new_Tox *tox, uint8_t const *name, size_t length, TOX_ERR
       if (error) *error = TOX_ERR_SET_INFO_TOO_LONG;
       return false;
     }
-  if (length > 0 && name == nullptr)
+  if (name == nullptr)
     {
       if (error) *error = TOX_ERR_SET_INFO_NULL;
       return false;
@@ -409,7 +409,7 @@ new_tox_self_set_status_message (new_Tox *tox, uint8_t const *status, size_t len
       if (error) *error = TOX_ERR_SET_INFO_TOO_LONG;
       return false;
     }
-  if (length > 0 && status == nullptr)
+  if (status == nullptr)
     {
       if (error) *error = TOX_ERR_SET_INFO_NULL;
       return false;

--- a/src/main/java/im/tox/tox4j/ToxCoreImpl.java
+++ b/src/main/java/im/tox/tox4j/ToxCoreImpl.java
@@ -23,11 +23,17 @@ public final class ToxCoreImpl extends AbstractToxCore {
     private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
 
     @NotNull
-    private static byte[] notNull(byte[] bytes) {
+    private static byte[] notNull(@Nullable byte[] bytes) {
         if (bytes == null) {
             bytes = EMPTY_BYTE_ARRAY;
         }
         return bytes;
+    }
+
+    private static void checkInfoNotNull(byte[] info) throws ToxSetInfoException {
+        if (info == null) {
+            throw new ToxSetInfoException(ToxSetInfoException.Code.NULL);
+        }
     }
 
     /**
@@ -383,6 +389,7 @@ public final class ToxCoreImpl extends AbstractToxCore {
 
     @Override
     public void setName(@NotNull byte[] name) throws ToxSetInfoException {
+        checkInfoNotNull(name);
         toxSelfSetName(instanceNumber, name);
     }
 
@@ -400,6 +407,7 @@ public final class ToxCoreImpl extends AbstractToxCore {
 
     @Override
     public void setStatusMessage(byte[] message) throws ToxSetInfoException {
+        checkInfoNotNull(message);
         toxSelfSetStatusMessage(instanceNumber, message);
     }
 

--- a/src/main/java/im/tox/tox4j/ToxCoreImpl.java
+++ b/src/main/java/im/tox/tox4j/ToxCoreImpl.java
@@ -22,6 +22,7 @@ public final class ToxCoreImpl extends AbstractToxCore {
 
     private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
 
+    @NotNull
     private static byte[] notNull(byte[] bytes) {
         if (bytes == null) {
             bytes = EMPTY_BYTE_ARRAY;
@@ -378,10 +379,10 @@ public final class ToxCoreImpl extends AbstractToxCore {
     }
 
 
-    private static native void toxSelfSetName(int instanceNumber, byte[] name) throws ToxSetInfoException;
+    private static native void toxSelfSetName(int instanceNumber, @NotNull byte[] name) throws ToxSetInfoException;
 
     @Override
-    public void setName(byte[] name) throws ToxSetInfoException {
+    public void setName(@NotNull byte[] name) throws ToxSetInfoException {
         toxSelfSetName(instanceNumber, name);
     }
 

--- a/src/main/java/im/tox/tox4j/core/ToxCore.java
+++ b/src/main/java/im/tox/tox4j/core/ToxCore.java
@@ -158,7 +158,7 @@ public interface ToxCore extends Closeable {
      * @param name our name.
      * @throws ToxSetInfoException if an error occurs.
      */
-    void setName(@Nullable byte[] name) throws ToxSetInfoException;
+    void setName(@NotNull byte[] name) throws ToxSetInfoException;
 
     /**
      * Get our own nickname. May be null if the nickname was empty.
@@ -176,7 +176,7 @@ public interface ToxCore extends Closeable {
      * @param message the status message to set.
      * @throws ToxSetInfoException if an error occurs.
      */
-    void setStatusMessage(@Nullable byte[] message) throws ToxSetInfoException;
+    void setStatusMessage(@NotNull byte[] message) throws ToxSetInfoException;
 
     /**
      * Gets our own status message. May be null if the status message was empty.

--- a/src/test/java/im/tox/tox4j/core/callbacks/NameEmptyTest.java
+++ b/src/test/java/im/tox/tox4j/core/callbacks/NameEmptyTest.java
@@ -8,7 +8,7 @@ import im.tox.tox4j.exceptions.ToxException;
 
 import static org.junit.Assert.assertEquals;
 
-public class NameNullTest extends AliceBobTestBase {
+public class NameEmptyTest extends AliceBobTestBase {
 
     @NotNull @Override protected ChatClient newAlice() {
         return new Alice();
@@ -37,7 +37,7 @@ public class NameNullTest extends AliceBobTestBase {
                 addTask(new Task() {
                     @Override
                     public void perform(@NotNull ToxCore tox) throws ToxException {
-                        tox.setName(null);
+                        tox.setName(new byte[]{});
                     }
                 });
             } else {

--- a/src/test/java/im/tox/tox4j/core/callbacks/StatusMessageEmptyTest.java
+++ b/src/test/java/im/tox/tox4j/core/callbacks/StatusMessageEmptyTest.java
@@ -8,7 +8,7 @@ import im.tox.tox4j.exceptions.ToxException;
 
 import static org.junit.Assert.assertEquals;
 
-public class StatusMessageNullTest extends AliceBobTestBase {
+public class StatusMessageEmptyTest extends AliceBobTestBase {
 
     @NotNull @Override protected ChatClient newAlice() {
         return new Alice();
@@ -37,7 +37,7 @@ public class StatusMessageNullTest extends AliceBobTestBase {
                 addTask(new Task() {
                     @Override
                     public void perform(@NotNull ToxCore tox) throws ToxException {
-                        tox.setStatusMessage(null);
+                        tox.setStatusMessage(new byte[]{});
                     }
                 });
             } else {

--- a/src/test/java/im/tox/tox4j/core/exceptions/ToxSetInfoExceptionTest.java
+++ b/src/test/java/im/tox/tox4j/core/exceptions/ToxSetInfoExceptionTest.java
@@ -32,4 +32,24 @@ public class ToxSetInfoExceptionTest extends ToxCoreImplTestBase {
         }
     }
 
+    @Test
+    public void testSetStatusMessageNull() throws Exception {
+        try (ToxCore tox = newTox()) {
+            tox.setStatusMessage(null);
+            fail();
+        } catch (ToxSetInfoException e) {
+            assertEquals(ToxSetInfoException.Code.NULL, e.getCode());
+        }
+    }
+
+    @Test
+    public void testSetNameNull() throws Exception {
+        try (ToxCore tox = newTox()) {
+            tox.setName(null);
+            fail();
+        } catch (ToxSetInfoException e) {
+            assertEquals(ToxSetInfoException.Code.NULL, e.getCode());
+        }
+    }
+
 }


### PR DESCRIPTION
This makes the API more consistent. The accessors never return null, so we should not allow null as a mutator argument either.