### PR TITLE
Unused events

### DIFF
--- a/src/main/cpp/ToxCore/clientinfo.cpp
+++ b/src/main/cpp/ToxCore/clientinfo.cpp
@@ -10,8 +10,9 @@ TOX_METHOD (jbyteArray, SelfGetPublicKey,
   jint instanceNumber)
 {
   return with_instance (env, instanceNumber,
-    [env] (Tox const *tox, Events &)
+    [env] (Tox const *tox, Events &events)
       {
+        unused (events);
         return get_array<uint8_t, TOX_PUBLIC_KEY_SIZE,
           tox_self_get_public_key> (env, tox);
       }
@@ -27,8 +28,9 @@ TOX_METHOD (jbyteArray, SelfGetSecretKey,
   jint instanceNumber)
 {
   return with_instance (env, instanceNumber,
-    [env] (Tox const *tox, Events &)
+    [env] (Tox const *tox, Events &events)
       {
+        unused (events);
         return get_array<uint8_t, TOX_SECRET_KEY_SIZE,
           tox_self_get_secret_key> (env, tox);
       }
@@ -78,8 +80,9 @@ TOX_METHOD (jbyteArray, SelfGetAddress,
   jint instanceNumber)
 {
   return with_instance (env, instanceNumber,
-    [env] (Tox const *tox, Events &)
+    [env] (Tox const *tox, Events &events)
       {
+        unused (events);
         return get_array<uint8_t, TOX_ADDRESS_SIZE,
           tox_self_get_address> (env, tox);
       }
@@ -122,8 +125,9 @@ TOX_METHOD (jbyteArray, SelfGetName,
   jint instanceNumber)
 {
   return with_instance (env, instanceNumber,
-    [env] (Tox const *tox, Events &)
+    [env] (Tox const *tox, Events &events)
       {
+        unused (events);
         return get_vector<uint8_t,
           tox_self_get_name_size,
           tox_self_get_name> (env, tox);
@@ -154,8 +158,9 @@ TOX_METHOD (jbyteArray, SelfGetStatusMessage,
   jint instanceNumber)
 {
   return with_instance (env, instanceNumber,
-    [env] (Tox const *tox, Events &)
+    [env] (Tox const *tox, Events &events)
       {
+        unused (events);
         return get_vector<uint8_t,
           tox_self_get_status_message_size,
           tox_self_get_status_message> (env, tox);

--- a/src/main/cpp/ToxCore/connection.cpp
+++ b/src/main/cpp/ToxCore/connection.cpp
@@ -113,8 +113,9 @@ TOX_METHOD (jbyteArray, GetDhtId,
   jint instanceNumber)
 {
   return with_instance (env, instanceNumber,
-    [env] (Tox const *tox, Events &)
+    [env] (Tox const *tox, Events &events)
       {
+        unused (events);
         return get_array<uint8_t, TOX_PUBLIC_KEY_SIZE,
           tox_self_get_dht_id> (env, tox);
       }

--- a/src/main/cpp/ToxCore/friendlist.cpp
+++ b/src/main/cpp/ToxCore/friendlist.cpp
@@ -156,8 +156,9 @@ TOX_METHOD (jintArray, FriendList,
   jint instanceNumber)
 {
   return with_instance (env, instanceNumber,
-    [env] (Tox const *tox, Events &)
+    [env] (Tox const *tox, Events &events)
       {
+        unused (events);
         return get_vector<uint32_t,
           tox_self_get_friend_list_size,
           tox_self_get_friend_list> (env, tox);

--- a/src/main/cpp/ToxCore/playground.cpp
+++ b/src/main/cpp/ToxCore/playground.cpp
@@ -9,8 +9,10 @@ METHOD (void, playground,
   jint instance_number)
 {
   return with_instance (env, instance_number,
-    [=] (Tox *, Events &)
+    [=] (Tox *tox, Events &events)
       {
+        unused (tox);
+        unused (events);
       }
   );
 }

--- a/src/main/java/im/tox/tox4j/ToxCoreImpl.java
+++ b/src/main/java/im/tox/tox4j/ToxCoreImpl.java
@@ -52,7 +52,7 @@ public final class ToxCoreImpl extends AbstractToxCore {
     /**
      * This field is set by {@link ToxAvImpl} on construction and reset back to null on close.
      */
-    ToxAvImpl av = null;
+    @Nullable ToxAvImpl av = null;
 
     private ConnectionStatusCallback connectionStatusCallback;
     private FriendNameCallback friendNameCallback;
@@ -77,7 +77,7 @@ public final class ToxCoreImpl extends AbstractToxCore {
 
 
     private static native int toxNew(
-        byte[] data,
+        @Nullable byte[] data,
         boolean ipv6Enabled,
         boolean udpEnabled,
         int proxyType,
@@ -85,20 +85,7 @@ public final class ToxCoreImpl extends AbstractToxCore {
         int proxyPort
     ) throws ToxNewException;
 
-    public ToxCoreImpl() throws ToxNewException {
-        this(new ToxOptions());
-    }
-
-    public ToxCoreImpl(@NotNull byte[] data) throws ToxNewException {
-        this(new ToxOptions(), data);
-    }
-
-    public ToxCoreImpl(@NotNull ToxOptions options) throws ToxNewException {
-        //noinspection ConstantConditions
-        this(options, null);
-    }
-
-    public ToxCoreImpl(@NotNull ToxOptions options, @NotNull byte[] data) throws ToxNewException {
+    public ToxCoreImpl(@NotNull ToxOptions options, @Nullable byte[] data) throws ToxNewException {
         instanceNumber = toxNew(
             data,
             options.isIpv6Enabled(),
@@ -136,9 +123,8 @@ public final class ToxCoreImpl extends AbstractToxCore {
 
     private static native byte[] toxSave(int instanceNumber);
 
-    @NotNull
     @Override
-    public byte[] save() {
+    public @NotNull byte[] save() {
         return toxSave(instanceNumber);
     }
 
@@ -146,15 +132,13 @@ public final class ToxCoreImpl extends AbstractToxCore {
     private static native void toxBootstrap(int instanceNumber, @NotNull String address, int port, @NotNull byte[] public_key) throws ToxBootstrapException;
     private static native void toxAddTcpRelay(int instanceNumber, @NotNull String address, int port, @NotNull byte[] public_key) throws ToxBootstrapException;
 
-    private static void checkBootstrapArguments(int port, byte[] public_key) {
+    private static void checkBootstrapArguments(int port, @Nullable byte[] public_key) {
         if (port < 0) {
             throw new IllegalArgumentException("Ports cannot be negative");
         }
         if (port > 65535) {
             throw new IllegalArgumentException("Ports cannot be larger than 65535");
         }
-        // Failing when it's null is toxBootstrap's job.
-        //noinspection ConstantConditions
         if (public_key != null) {
             if (public_key.length < ToxConstants.PUBLIC_KEY_SIZE) {
                 throw new IllegalArgumentException("Key too short, must be " + ToxConstants.PUBLIC_KEY_SIZE + " bytes");
@@ -202,9 +186,8 @@ public final class ToxCoreImpl extends AbstractToxCore {
 
     private static native @NotNull byte[] toxGetDhtId(int instanceNumber);
 
-    @NotNull
     @Override
-    public byte[] getDhtId() {
+    public @NotNull byte[] getDhtId() {
         return toxGetDhtId(instanceNumber);
     }
 
@@ -345,18 +328,16 @@ public final class ToxCoreImpl extends AbstractToxCore {
 
     private static native @NotNull byte[] toxSelfGetPublicKey(int instanceNumber);
 
-    @NotNull
     @Override
-    public byte[] getPublicKey() {
+    public @NotNull byte[] getPublicKey() {
         return toxSelfGetPublicKey(instanceNumber);
     }
 
 
     private static native @NotNull byte[] toxSelfGetSecretKey(int instanceNumber);
 
-    @NotNull
     @Override
-    public byte[] getSecretKey() {
+    public @NotNull byte[] getSecretKey() {
         return toxSelfGetSecretKey(instanceNumber);
     }
 
@@ -379,9 +360,8 @@ public final class ToxCoreImpl extends AbstractToxCore {
 
     private static native @NotNull byte[] toxSelfGetAddress(int instanceNumber);
 
-    @NotNull
     @Override
-    public byte[] getAddress() {
+    public @NotNull byte[] getAddress() {
         return toxSelfGetAddress(instanceNumber);
     }
 
@@ -397,9 +377,8 @@ public final class ToxCoreImpl extends AbstractToxCore {
 
     private static native @Nullable byte[] toxSelfGetName(int instanceNumber);
 
-    @NotNull
     @Override
-    public byte[] getName() {
+    public @NotNull byte[] getName() {
         return notNull(toxSelfGetName(instanceNumber));
     }
 
@@ -415,9 +394,8 @@ public final class ToxCoreImpl extends AbstractToxCore {
 
     private static native @Nullable byte[] toxSelfGetStatusMessage(int instanceNumber);
 
-    @NotNull
     @Override
-    public byte[] getStatusMessage() {
+    public @NotNull byte[] getStatusMessage() {
         return notNull(toxSelfGetStatusMessage(instanceNumber));
     }
 
@@ -432,9 +410,8 @@ public final class ToxCoreImpl extends AbstractToxCore {
 
     private static native int toxSelfGetStatus(int instanceNumber);
 
-    @NotNull
     @Override
-    public ToxStatus getStatus() {
+    public @NotNull ToxStatus getStatus() {
         return ToxStatus.values()[toxSelfGetStatus(instanceNumber)];
     }
 
@@ -487,9 +464,8 @@ public final class ToxCoreImpl extends AbstractToxCore {
 
     private static native @NotNull byte[] toxFriendGetPublicKey(int instanceNumber, int friendNumber) throws ToxFriendGetPublicKeyException;
 
-    @NotNull
     @Override
-    public byte[] getPublicKey(int friendNumber) throws ToxFriendGetPublicKeyException {
+    public @NotNull byte[] getPublicKey(int friendNumber) throws ToxFriendGetPublicKeyException {
         return toxFriendGetPublicKey(instanceNumber, friendNumber);
     }
 
@@ -504,9 +480,8 @@ public final class ToxCoreImpl extends AbstractToxCore {
 
     private static native @NotNull int[] toxFriendList(int instanceNumber);
 
-    @NotNull
     @Override
-    public int[] getFriendList() {
+    public @NotNull int[] getFriendList() {
         return notNull(toxFriendList(instanceNumber));
     }
 

--- a/src/main/scala/im/tox/client/ToxClient.scala
+++ b/src/main/scala/im/tox/client/ToxClient.scala
@@ -6,7 +6,7 @@ import im.tox.tox4j.core.{ToxCore, ToxOptions}
 
 class ToxClient {
 
-  private val tox: ToxCore = new ToxCoreImpl(new ToxOptions)
+  private val tox: ToxCore = new ToxCoreImpl(new ToxOptions, null)
 
   def name: String = new String(tox.getName)
   def name_=(name: String) = tox.setName(name.getBytes)

--- a/src/test/java/im/tox/gui/ToxGui.java
+++ b/src/test/java/im/tox/gui/ToxGui.java
@@ -329,7 +329,7 @@ public class ToxGui extends JFrame {
                             friendListModel.add(friendNumber, tox.getPublicKey(friendNumber));
                         }
                     } else {
-                        tox = new ToxCoreImpl(options);
+                        tox = new ToxCoreImpl(options, null);
                     }
                     selfPublicKey.setText(readablePublicKey(tox.getAddress()));
                     tox.callback(toxEvents);

--- a/src/test/java/im/tox/tox4j/ToxAvImplTestBase.java
+++ b/src/test/java/im/tox/tox4j/ToxAvImplTestBase.java
@@ -21,7 +21,7 @@ public abstract class ToxAvImplTestBase extends ToxAvTestBase {
             ToxOptions options = new ToxOptions();
             options.setIpv6Enabled(ipv6Enabled);
             options.setUdpEnabled(udpEnabled);
-            return new ToxCoreImpl(options);
+            return new ToxCoreImpl(options, null);
         }
     });
 

--- a/src/test/java/im/tox/tox4j/ToxCoreImplTestBase.java
+++ b/src/test/java/im/tox/tox4j/ToxCoreImplTestBase.java
@@ -18,7 +18,7 @@ public abstract class ToxCoreImplTestBase extends ToxCoreTestBase {
             ToxOptions options = new ToxOptions();
             options.setIpv6Enabled(ipv6Enabled);
             options.setUdpEnabled(udpEnabled);
-            return new ToxCoreImpl(options);
+            return new ToxCoreImpl(options, null);
         }
     });
 
@@ -33,9 +33,8 @@ public abstract class ToxCoreImplTestBase extends ToxCoreTestBase {
         System.gc();
     }
 
-    @NotNull
     @Override
-    protected final ToxCore newTox(ToxOptions options, byte[] data) throws ToxNewException {
+    protected final @NotNull ToxCore newTox(ToxOptions options, byte[] data) throws ToxNewException {
         ToxCoreImpl tox = new ToxCoreImpl(options, data);
         toxes.add(tox);
         return tox;

--- a/src/test/java/im/tox/tox4j/ToxCorePlayground.java
+++ b/src/test/java/im/tox/tox4j/ToxCorePlayground.java
@@ -6,7 +6,7 @@ import im.tox.tox4j.exceptions.ToxException;
 public final class ToxCorePlayground {
 
     public static void main(String[] args) throws ToxException {
-        try (ToxCoreImpl tox = new ToxCoreImpl(new ToxOptions())) {
+        try (ToxCoreImpl tox = new ToxCoreImpl(new ToxOptions(), null)) {
             tox.playground();
         }
     }

--- a/src/test/java/im/tox/tox4j/ToxCoreTestBase.java
+++ b/src/test/java/im/tox/tox4j/ToxCoreTestBase.java
@@ -48,8 +48,7 @@ public abstract class ToxCoreTestBase {
 
     protected abstract @NotNull DhtNode node();
 
-    protected abstract @NotNull
-    ToxCore newTox(ToxOptions options, byte[] data) throws ToxNewException;
+    protected abstract @NotNull ToxCore newTox(ToxOptions options, byte[] data) throws ToxNewException;
 
     protected final @NotNull ToxCore newTox() throws ToxNewException {
         return newTox(new ToxOptions(), null);

--- a/src/test/java/im/tox/tox4j/core/NetworkTest.java
+++ b/src/test/java/im/tox/tox4j/core/NetworkTest.java
@@ -18,7 +18,11 @@ public class NetworkTest extends ToxCoreImplTestBase {
         try (ToxCore tox = newTox(ipv6Enabled, udpEnabled)) {
             logger.info("Attempting to {}", action);
             long start = System.currentTimeMillis();
-            tox.bootstrap(ip, port, dhtId);
+            if (udpEnabled) {
+                tox.bootstrap(ip, port, dhtId);
+            } else {
+                tox.addTcpRelay(ip, port, dhtId);
+            }
             ConnectedListener status = new ConnectedListener();
             tox.callbackConnectionStatus(status);
             while (!status.isConnected()) {

--- a/src/test/java/im/tox/tox4j/core/RepeatedLanDiscoveryTest.java
+++ b/src/test/java/im/tox/tox4j/core/RepeatedLanDiscoveryTest.java
@@ -8,8 +8,9 @@ public final class RepeatedLanDiscoveryTest {
     public static void main(String[] args) throws Exception {
         for (int i = 0; i < 1000; i++) {
             System.out.println("Cycle " + i);
-            try (ToxCore tox1 = new ToxCoreImpl()) {
-                try (ToxCore tox2 = new ToxCoreImpl()) {
+            ToxOptions options = new ToxOptions();
+            try (ToxCore tox1 = new ToxCoreImpl(options, null)) {
+                try (ToxCore tox2 = new ToxCoreImpl(options, null)) {
                     ConnectedListener status = new ConnectedListener();
                     tox1.callbackConnectionStatus(status);
                     tox2.callbackConnectionStatus(status);

--- a/src/test/scala/TestClient.scala
+++ b/src/test/scala/TestClient.scala
@@ -62,7 +62,7 @@ object TestClient extends App {
           options.setIpv6Enabled(true)
           options.setUdpEnabled(bootstrap.isEmpty)
           options
-        })
+        }, null)
 
         tox.callback(new TestEventListener(id))
         logger.info(s"[$id] Key: ${readablePublicKey(tox.getPublicKey)}")


### PR DESCRIPTION
Instead of leaving out parameter names, use the unused(...) macro consistently