### PR TITLE
Split UDP and TCP port in nodes

### DIFF
--- a/src/test/java/im/tox/tox4j/AliceBobTestBase.java
+++ b/src/test/java/im/tox/tox4j/AliceBobTestBase.java
@@ -259,7 +259,7 @@ public abstract class AliceBobTestBase extends ToxCoreImplTestBase {
             @NotNull
             @Override
             public ToxCore make() throws ToxException {
-                return bootstrap(false, newTox(false, false));
+                return bootstrap(false, false, newTox(false, false));
             }
         });
     }
@@ -271,7 +271,7 @@ public abstract class AliceBobTestBase extends ToxCoreImplTestBase {
             @NotNull
             @Override
             public ToxCore make() throws ToxException {
-                return bootstrap(true, newTox(true, false));
+                return bootstrap(true, false, newTox(true, false));
             }
         });
     }
@@ -290,7 +290,7 @@ public abstract class AliceBobTestBase extends ToxCoreImplTestBase {
                 @NotNull
                 @Override
                 public ToxCore make() throws ToxException {
-                    return bootstrap(ipv6Enabled, newTox(ipv6Enabled, udpEnabled, ToxProxyType.SOCKS5, proxy.getAddress(), proxy.getPort()));
+                    return bootstrap(ipv6Enabled, udpEnabled, newTox(ipv6Enabled, udpEnabled, ToxProxyType.SOCKS5, proxy.getAddress(), proxy.getPort()));
                 }
             });
         } finally {

--- a/src/test/java/im/tox/tox4j/DhtNode.java
+++ b/src/test/java/im/tox/tox4j/DhtNode.java
@@ -3,13 +3,24 @@ package im.tox.tox4j;
 public class DhtNode {
     public final String ipv4;
     public final String ipv6;
-    public final int port;
+    public final int tcpPort;
+    public final int udpPort;
     public final byte[] dhtId;
 
     public DhtNode(String ipv4, String ipv6, int port, String dhtId) {
         this.ipv4 = ipv4;
         this.ipv6 = ipv6;
-        this.port = port;
+        this.tcpPort = port;
+        this.udpPort = port;
         this.dhtId = ToxCoreTestBase.parsePublicKey(dhtId);
     }
+
+    public DhtNode(String ipv4, String ipv6, int udpPort, int tcpPort, String dhtId) {
+        this.ipv4 = ipv4;
+        this.ipv6 = ipv6;
+        this.tcpPort = tcpPort;
+        this.udpPort = udpPort;
+        this.dhtId = ToxCoreTestBase.parsePublicKey(dhtId);
+    }
+
 }

--- a/src/test/java/im/tox/tox4j/DhtNodeSelector.java
+++ b/src/test/java/im/tox/tox4j/DhtNodeSelector.java
@@ -27,7 +27,7 @@ public final class DhtNodeSelector {
         logger.info("Looking for a working bootstrap node");
         for (DhtNode node : ToxCoreTestBase.nodeCandidates) {
             logger.info("Trying to establish a TCP connection to {}", node.ipv4);
-            try (Socket socket = new Socket(InetAddress.getByName(node.ipv4), node.port)) {
+            try (Socket socket = new Socket(InetAddress.getByName(node.ipv4), node.tcpPort)) {
                 assumeNotNull(socket.getInputStream());
             } catch (IOException e) {
                 logger.info("TCP connection failed ({})", e.getMessage());
@@ -43,7 +43,7 @@ public final class DhtNodeSelector {
                     ConnectedListener status = new ConnectedListener();
                     tox.callbackConnectionStatus(status);
 
-                    tox.bootstrap(node.ipv4, node.port, node.dhtId);
+                    tox.bootstrap(node.ipv4, udpEnabled ? node.udpPort : node.tcpPort, node.dhtId);
                     long startTime = System.currentTimeMillis();
                     final long TIMEOUT = 10000;
 

--- a/src/test/java/im/tox/tox4j/ToxCoreTestBase.java
+++ b/src/test/java/im/tox/tox4j/ToxCoreTestBase.java
@@ -27,7 +27,7 @@ public abstract class ToxCoreTestBase {
 
     static final DhtNode[] nodeCandidates = {
         new DhtNode("192.254.75.102", "2607:5600:284::2", 33445, "951C88B7E75C867418ACDB5D273821372BB5BD652740BCDF623A4FA293E75D2F"),
-        new DhtNode("144.76.60.215", "2a01:4f8:191:64d6::1", 33445, "04119E835DF3E78BACF0F84235B300546AF8B936F035185E2A8E9E0A67C8924F"),
+        new DhtNode("144.76.60.215", "2a01:4f8:191:64d6::1", 33445, 33445, "04119E835DF3E78BACF0F84235B300546AF8B936F035185E2A8E9E0A67C8924F"),
         new DhtNode("23.226.230.47", "2604:180:1::3ded:b280", 33445, "A09162D68618E742FFBCA1C2C70385E6679604B2D80EA6E84AD0996A1AC8A074"),
         new DhtNode("178.62.125.224", "2a03:b0c0:1:d0::178:6001", 33445, "10B20C49ACBD968D7C80F2E8438F92EA51F189F4E70CFBBB2C2C8C799E97F03E"),
         new DhtNode("178.21.112.187", "2a02:2308::216:3eff:fe82:eaef", 33445, "4B2C19E924972CB9B57732FB172F8A8604DE13EEDA2A6234E348983344B23057"),
@@ -232,12 +232,8 @@ public abstract class ToxCoreTestBase {
         assumeConnection("2001:4860:4860::8888", 53);
     }
 
-    @NotNull ToxCore bootstrap(boolean useIPv6, @NotNull ToxCore tox) throws ToxBootstrapException {
-        if (useIPv6) {
-            tox.bootstrap(node().ipv6, node().port, node().dhtId);
-        } else {
-            tox.bootstrap(node().ipv4, node().port, node().dhtId);
-        }
+    @NotNull ToxCore bootstrap(boolean useIPv6, boolean udpEnabled, @NotNull ToxCore tox) throws ToxBootstrapException {
+        tox.bootstrap(useIPv6 ? node().ipv6 : node().ipv4, udpEnabled ? node().udpPort : node().tcpPort, node().dhtId);
         return tox;
     }
 

--- a/src/test/java/im/tox/tox4j/core/InterruptionTest.java
+++ b/src/test/java/im/tox/tox4j/core/InterruptionTest.java
@@ -19,7 +19,7 @@ public final class InterruptionTest extends ToxCoreImplTestBase {
                 public void run() {
                     System.out.println("Survived " + cycle + " seconds");
                     try (ToxCore tox = newTox()) {
-                        tox.bootstrap(node().ipv4, node().port, node().dhtId);
+                        tox.bootstrap(node().ipv4, node().udpPort, node().dhtId);
                         //noinspection InfiniteLoopStatement
                         while (true) {
                             tox.iteration();

--- a/src/test/java/im/tox/tox4j/core/NetworkTest.java
+++ b/src/test/java/im/tox/tox4j/core/NetworkTest.java
@@ -13,8 +13,8 @@ public class NetworkTest extends ToxCoreImplTestBase {
     private static final int TOX_COUNT = 10;
 
     private void testBootstrap(boolean ipv6Enabled, boolean udpEnabled, String ip, int port, byte[] dhtId) throws Exception {
-        String action = String.format("bootstrap to remote node on %s with %s%d",
-            ip, udpEnabled ? "UDP" : "TCP", ipv6Enabled ? 6 : 4);
+        String action = String.format("bootstrap to remote node on %s:%d with %s%d",
+            ip, port, udpEnabled ? "UDP" : "TCP", ipv6Enabled ? 6 : 4);
         try (ToxCore tox = newTox(ipv6Enabled, udpEnabled)) {
             logger.info("Attempting to {}", action);
             long start = System.currentTimeMillis();
@@ -41,25 +41,25 @@ public class NetworkTest extends ToxCoreImplTestBase {
     @Test(timeout = TIMEOUT)
     public void testBootstrap4_UDP() throws Exception {
         assumeIPv4();
-        testBootstrap(false, true, node().ipv4, node().port, node().dhtId);
+        testBootstrap(false, true, node().ipv4, node().udpPort, node().dhtId);
     }
 
     @Test(timeout = TIMEOUT)
     public void testBootstrap6_UDP() throws Exception {
         assumeIPv6();
-        testBootstrap(true, true, node().ipv6, node().port, node().dhtId);
+        testBootstrap(true, true, node().ipv6, node().udpPort, node().dhtId);
     }
 
     @Test(timeout = TIMEOUT)
     public void testBootstrap4_TCP() throws Exception {
         assumeIPv4();
-        testBootstrap(false, false, node().ipv4, node().port, node().dhtId);
+        testBootstrap(false, false, node().ipv4, node().tcpPort, node().dhtId);
     }
 
     @Test(timeout = TIMEOUT)
     public void testBootstrap6_TCP() throws Exception {
         assumeIPv6();
-        testBootstrap(true, false, node().ipv6, node().port, node().dhtId);
+        testBootstrap(true, false, node().ipv6, node().tcpPort, node().dhtId);
     }
 
     @Test


### PR DESCRIPTION
This allows for more flexible testing in the future.