### PR TITLE
Change method per class limit to 60

### DIFF
--- a/src/main/java/scalastyle-config.xml
+++ b/src/main/java/scalastyle-config.xml
@@ -108,7 +108,7 @@
  </check>
  <check level="error" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">
   <parameters>
-   <parameter name="maxMethods"><![CDATA[30]]></parameter>
+   <parameter name="maxMethods"><![CDATA[60]]></parameter>
   </parameters>
  </check>
  <check level="error" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>

--- a/src/test/java/scalastyle-config.xml
+++ b/src/test/java/scalastyle-config.xml
@@ -108,7 +108,7 @@
  </check>
  <check level="error" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">
   <parameters>
-   <parameter name="maxMethods"><![CDATA[30]]></parameter>
+   <parameter name="maxMethods"><![CDATA[60]]></parameter>
   </parameters>
  </check>
  <check level="error" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>


### PR DESCRIPTION
The current method per class limit of the scalastyle-checker is 30 which printed errors for classes implementing ToxCore (a bit more than 50 methods).