### PR TITLE
Use "master" branch for travis builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,4 @@ before_cache:
 
 branches:
   only:
-    - auto
-
-notifications:
-  webhooks: http://slevermann.de:54856/travis
+    - master


### PR DESCRIPTION
Also, stop sending notifications to sonOfRa's thing. It's unmaintained
and we can't use it right now.