### PR TITLE
Change constant names to upper camel case.

### DIFF
--- a/projects/tox4j/src/test/java/im/tox/tox4j/core/ToxCoreConstantsTest.scala
+++ b/projects/tox4j/src/test/java/im/tox/tox4j/core/ToxCoreConstantsTest.scala
@@ -5,70 +5,70 @@ import org.scalatest.FunSuite
 
 final class ToxCoreConstantsTest extends FunSuite {
 
-  test("MAX_FRIEND_REQUEST_LENGTH") {
+  test("MaxFriendRequestLength") {
     assert(ToxCoreConstants.MaxFriendRequestLength > 0)
     assert(ToxCoreConstants.MaxFriendRequestLength < ToxCoreConstants.MaxCustomPacketSize)
   }
 
-  test("PUBLIC_KEY_SIZE") {
+  test("PublicKeySize") {
     assert(ToxCoreConstants.PublicKeySize == ToxCoreConstants.SecretKeySize)
     assert(ToxCoreConstants.PublicKeySize >= 32)
     assert(ToxCoreConstants.SecretKeySize >= 32)
   }
 
-  test("MAX_NAME_LENGTH") {
+  test("MaxNameLength") {
     assert(ToxCoreConstants.MaxNameLength > 0)
     assert(ToxCoreConstants.MaxNameLength < ToxCoreConstants.MaxCustomPacketSize)
   }
 
-  test("MAX_FILENAME_LENGTH") {
+  test("MaxFilenameLength") {
     assert(ToxCoreConstants.MaxFilenameLength > 0)
     assert(ToxCoreConstants.MaxFilenameLength < ToxCoreConstants.MaxCustomPacketSize)
   }
 
-  test("MAX_CUSTOM_PACKET_SIZE") {
+  test("MaxCustomPacketSize") {
     assert(ToxCoreConstants.MaxCustomPacketSize > 0)
     assert(ToxCoreConstants.MaxCustomPacketSize <= 1500) // Ethernet MTU
   }
 
-  test("MAX_HOSTNAME_LENGTH") {
+  test("MaxHostnameLength") {
     assert(ToxCoreConstants.MaxHostnameLength > 0)
   }
 
-  test("TOX_ADDRESS_SIZE") {
+  test("AddressSize") {
     assert(ToxCoreConstants.AddressSize >= ToxCoreConstants.AddressSize)
   }
 
-  test("FILE_ID_LENGTH") {
+  test("FileIdLength") {
     assert(ToxCoreConstants.FileIdLength >= ToxCryptoConstants.HashLength)
   }
 
-  test("DEFAULT_END_PORT") {
+  test("DefaultEndPort") {
     assert(ToxCoreConstants.DefaultEndPort >= 1)
     assert(ToxCoreConstants.DefaultEndPort <= 65535)
   }
 
-  test("MAX_MESSAGE_LENGTH") {
+  test("MaxMessageLength") {
     assert(ToxCoreConstants.MaxMessageLength > 0)
     assert(ToxCoreConstants.MaxMessageLength < ToxCoreConstants.MaxCustomPacketSize)
   }
 
-  test("MAX_STATUS_MESSAGE_LENGTH") {
+  test("MaxStatusMessageLength") {
     assert(ToxCoreConstants.MaxStatusMessageLength > 0)
     assert(ToxCoreConstants.MaxStatusMessageLength < ToxCoreConstants.MaxCustomPacketSize)
   }
 
-  test("DEFAULT_TCP_PORT") {
+  test("DefaultTcpPort") {
     assert(ToxCoreConstants.DefaultTcpPort >= 0) // 0 means no TCP
     assert(ToxCoreConstants.DefaultTcpPort <= 65535)
   }
 
-  test("DEFAULT_START_PORT") {
+  test("DefaultStartPort") {
     assert(ToxCoreConstants.DefaultStartPort >= 1)
     assert(ToxCoreConstants.DefaultStartPort <= 65535)
   }
 
-  test("DEFAULT_PROXY_PORT") {
+  test("DefaultProxyPort") {
     assert(ToxCoreConstants.DefaultProxyPort >= 1)
     assert(ToxCoreConstants.DefaultProxyPort <= 65535)
   }


### PR DESCRIPTION
Per http://docs.scala-lang.org/style/naming-conventions.html
Fixes #141